### PR TITLE
Lighter event functions, customizable lowpass

### DIFF
--- a/DPEng_ICM20948_AK09916.cpp
+++ b/DPEng_ICM20948_AK09916.cpp
@@ -186,7 +186,7 @@ DPEng_ICM20948::DPEng_ICM20948(int32_t accelSensorID, int32_t gyroSensorID, int3
      @return True if the device was successfully initialized, otherwise false.
  */
  /**************************************************************************/
-bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rngGyro)
+bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rngGyro, icm20948AccelLowpass_t lowAccel)
 {
   /* Enable I2C */
   Wire.begin();
@@ -262,7 +262,7 @@ bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rn
       break;
   }
   reg1 = reg1 | 0x01; // Set enable accel DLPF for the accelerometer
-  reg1 = reg1 | 0x18; // and set DLFPFCFG to 50.4 hz
+  reg1 = reg1 | lowAccel; // and set DLFPFCFG to 50.4 hz
 	
   // Write new ACCEL_CONFIG register value
   write8(ACCEL_CONFIG, reg1);

--- a/DPEng_ICM20948_AK09916.cpp
+++ b/DPEng_ICM20948_AK09916.cpp
@@ -181,12 +181,14 @@ DPEng_ICM20948::DPEng_ICM20948(int32_t accelSensorID, int32_t gyroSensorID, int3
      @param  rngAccel
              The range to set for the accelerometer, based on icm20948AccelRange_t
 	 @param  rngGyro
-             The range to set for the gyroscope, based on icm20948GyroRange_t		 
+             The range to set for the gyroscope, based on icm20948GyroRange_t		
+	 @param  lowpassAccel
+             The lowpass configuration of the accelerometer, based on icm20948AccelLowpass_t	 
 
      @return True if the device was successfully initialized, otherwise false.
  */
  /**************************************************************************/
-bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rngGyro, icm20948AccelLowpass_t lowAccel)
+bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rngGyro, icm20948AccelLowpass_t lowpassAccel)
 {
   /* Enable I2C */
   Wire.begin();
@@ -262,7 +264,7 @@ bool DPEng_ICM20948::begin(icm20948AccelRange_t rngAccel, icm20948GyroRange_t rn
       break;
   }
   reg1 = reg1 | 0x01; // Set enable accel DLPF for the accelerometer
-  reg1 = reg1 | lowAccel; // and set DLFPFCFG to 50.4 hz
+  reg1 = reg1 | lowpassAccel; // and set DLFPFCFG to 50.4 hz
 	
   // Write new ACCEL_CONFIG register value
   write8(ACCEL_CONFIG, reg1);

--- a/DPEng_ICM20948_AK09916.h
+++ b/DPEng_ICM20948_AK09916.h
@@ -287,7 +287,7 @@ class DPEng_ICM20948 : public Adafruit_Sensor
   public:
     DPEng_ICM20948(int32_t accelSensorID = -1, int32_t gyroSensorID = -1, int32_t magSensorID = -1);
 
-    bool begin           ( icm20948AccelRange_t rngAccel = ICM20948_ACCELRANGE_2G, icm20948GyroRange_t rngGyro = GYRO_RANGE_250DPS, icm20948AccelLowpass_t lowAccel = ICM20948_ACCELLOWPASS_50_4_HZ );
+    bool begin           ( icm20948AccelRange_t rngAccel = ICM20948_ACCELRANGE_2G, icm20948GyroRange_t rngGyro = GYRO_RANGE_250DPS, icm20948AccelLowpass_t lowpassAccel = ICM20948_ACCELLOWPASS_50_4_HZ );
     bool getEventAcc     ( sensors_event_t* accel );
     bool getEventMag     ( sensors_event_t* mag );
     bool getEvent        ( sensors_event_t* accel );

--- a/DPEng_ICM20948_AK09916.h
+++ b/DPEng_ICM20948_AK09916.h
@@ -274,6 +274,8 @@ class DPEng_ICM20948 : public Adafruit_Sensor
     DPEng_ICM20948(int32_t accelSensorID = -1, int32_t gyroSensorID = -1, int32_t magSensorID = -1);
 
     bool begin           ( icm20948AccelRange_t rngAccel = ICM20948_ACCELRANGE_2G, icm20948GyroRange_t rngGyro = GYRO_RANGE_250DPS );
+    bool getEventAcc     ( sensors_event_t* accel );
+    bool getEventMag     ( sensors_event_t* mag );
     bool getEvent        ( sensors_event_t* accel );
     void getSensor       ( sensor_t* accel );
     bool getEvent        ( sensors_event_t* accel, sensors_event_t* gyro, sensors_event_t* mag );

--- a/DPEng_ICM20948_AK09916.h
+++ b/DPEng_ICM20948_AK09916.h
@@ -247,6 +247,20 @@
       GYRO_RANGE_1000DPS = 1000,    /**< 1000dps */
       GYRO_RANGE_2000DPS = 2000     /**< 2000dps */
     } icm20948GyroRange_t;
+
+    /*!
+        Lowpass settings for the accelerometer sensor.
+    */
+    typedef enum
+    {
+      ICM20948_ACCELLOWPASS_473_0_HZ        = (0b111 << 3),
+      ICM20948_ACCELLOWPASS_246_0_HZ        = (0b001 << 3),
+      ICM20948_ACCELLOWPASS_111_4_HZ        = (0b010 << 3),
+      ICM20948_ACCELLOWPASS_50_4_HZ         = (0b011 << 3),
+      ICM20948_ACCELLOWPASS_23_9_HZ         = (0b100 << 3),
+      ICM20948_ACCELLOWPASS_11_5_HZ         = (0b101 << 3),
+      ICM20948_ACCELLOWPASS_5_7_HZ          = (0b110 << 3)
+    } icm20948AccelLowpass_t;
 /*=========================================================================*/
 
 /*=========================================================================
@@ -273,7 +287,7 @@ class DPEng_ICM20948 : public Adafruit_Sensor
   public:
     DPEng_ICM20948(int32_t accelSensorID = -1, int32_t gyroSensorID = -1, int32_t magSensorID = -1);
 
-    bool begin           ( icm20948AccelRange_t rngAccel = ICM20948_ACCELRANGE_2G, icm20948GyroRange_t rngGyro = GYRO_RANGE_250DPS );
+    bool begin           ( icm20948AccelRange_t rngAccel = ICM20948_ACCELRANGE_2G, icm20948GyroRange_t rngGyro = GYRO_RANGE_250DPS, icm20948AccelLowpass_t lowAccel = ICM20948_ACCELLOWPASS_50_4_HZ );
     bool getEventAcc     ( sensors_event_t* accel );
     bool getEventMag     ( sensors_event_t* mag );
     bool getEvent        ( sensors_event_t* accel );

--- a/examples/ahrs_calibration_usb/ahrs_calibration_usb.ino
+++ b/examples/ahrs_calibration_usb/ahrs_calibration_usb.ino
@@ -22,7 +22,7 @@ void setup()
   Serial.println(F("DPEng 9 DOF AHRS Calibration Example")); Serial.println("");
 
   // Initialize the sensors.
-  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS))
+  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS, ICM20948_ACCELLOWPASS_50_4_HZ))
   {
     /* There was a problem detecting the sensor ... check your connections */
     Serial.println("Ooops, no sensor detected ... Check your wiring!");

--- a/examples/ahrs_fusion_usb/ahrs_fusion_usb.ino
+++ b/examples/ahrs_fusion_usb/ahrs_fusion_usb.ino
@@ -41,7 +41,7 @@ void setup()
   Serial.println(F("DPEng AHRS Fusion Example")); Serial.println("");
 
   // Initialize the sensors.
-  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS))
+  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS, ICM20948_ACCELLOWPASS_50_4_HZ))
   {
     /* There was a problem detecting the ICM20948 ... check your connections */
     Serial.println("Ooops, no ICM20948/AK09916 detected ... Check your wiring!");

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -50,7 +50,7 @@ void displaySensorDetails(void)
 
 void setup(void)
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
 
   /* Wait for the Serial Monitor */
   while (!Serial) {
@@ -60,7 +60,7 @@ void setup(void)
   Serial.println("ICM20948 Test"); Serial.println("");
 
   /* Initialise the sensor */
-  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS))
+  if(!dpEng.begin(ICM20948_ACCELRANGE_4G, GYRO_RANGE_250DPS, ICM20948_ACCELLOWPASS_50_4_HZ))
   {
     /* There was a problem detecting the ICM20948 ... check your connections */
     Serial.println("Ooops, no ICM20948/AK09916 detected ... Check your wiring!");


### PR DESCRIPTION
I have done some changes to the original library:
- Added 2 new functions: `getEventAcc` and `getEventMag`. These two functions have a lower overhead, performing read requests only for the accelerometer and magnetometer respectively. This lowers the execution time from around 3000 us to 1300 us and 1100 us respectively. I have added these as I needed to sample the accelerometer at a high rate.
- Added a third parameter to the `begin` function: `lowAccel`. This parameter specifies the lowpass filter which will be ran internally on the accelerometer, and the user can choose from any defined in the `icm20948AccelLowpass_t` enum. I have done this as I needed to change the lowpass filter from the 50.4 Hz which was originally hardcoded.